### PR TITLE
fix: dotfiles loading in window11

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,14 +1,26 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
 
 class Config:
-    DB_USER = os.getenv("DB_USER")
-    DB_PASSWORD = os.getenv("DB_PASSWORD")
-    DB_DATABASE = os.getenv("DB_DATABASE")
-    DB_HOST = os.getenv("DB_HOST")
+    def __init__(self) -> None:
+        load_dotenv(dotenv_path=self.get_env_path())
+        self.DB_USER = os.getenv("DB_USER")
+        self.DB_PASSWORD = os.getenv("DB_PASSWORD")
+        self.DB_DATABASE = os.getenv("DB_DATABASE")
+        self.DB_HOST = os.getenv("DB_HOST")
 
-    @classmethod
-    def get_database_url(cls):
-        return f"mysql://{cls.DB_USER}:{cls.DB_PASSWORD}@{cls.DB_HOST}/{cls.DB_DATABASE}"
+    def get_database_url(self):
+        return f"mysql://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}/{self.DB_DATABASE}"
+    
+    def get_env_path(self):
+        """
+        Finds the absolute path of the .env file.
+        NOTE: 윈도우의 경우, load_dotenv 파일을 호출할 때 절대 경로를 인자로 줘야 정상 작동합니다.
+        """
+        current_dir = os.path.dirname(__file__)
+        env_file = '.env'
+        env_path = os.path.join(current_dir, env_file)
+        return env_path
+
+

--- a/app/database.py
+++ b/app/database.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import sessionmaker
 from app.config import Config
 from app.logger import logger
 
-def setup_database():
-    database_url = Config.get_database_url()
+def setup_database(config):
+    database_url = config.get_database_url()
     engine = create_engine(database_url)
     logger.info('DB: Connected to database')
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,14 @@
 from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.config import Config
 from app.models import Item
 from app.database import setup_database
 from app.schemas import ItemCreate
 
 app = FastAPI()
-SessionLocal = setup_database()
+config = Config()
+SessionLocal = setup_database(config)
 
 # Dependency: Database Session
 def get_db():


### PR DESCRIPTION
버그 수정
- README의 설명대로 수행했지만 환경변수를 가져오는 과정에서 항상 none을 반환했습니다.
- windows는 환경변수를 불러올 때 절대경로를 인자로 주어야 합니다.
- config.py에서 get_env_path의 함수를 생성해 이를 불러오고 join하여 setup할 수 있도록 했습니다.

@IamGroooooot Mac에서도 실행되는지 테스트해주세요.
